### PR TITLE
Changed req.params.index to req.params.id

### DIFF
--- a/server.js
+++ b/server.js
@@ -59,7 +59,7 @@ _getImage = function( req, res, next ) {
         isRetina = true;
     }
 
-    visualCaptcha.streamImage( req.params.index, res, isRetina );
+    visualCaptcha.streamImage( req.params.id, res, isRetina );
 };
 
 // Start and refresh captcha options


### PR DESCRIPTION
The angularjs frontend sends 'id' as the request parameter instead of 'index'.
